### PR TITLE
fix: set standard domain to be used

### DIFF
--- a/custom_auth/views.py
+++ b/custom_auth/views.py
@@ -10,7 +10,8 @@ def oauth_login(request):
     supabase = get_supabase(request)
     invitation_id = request.GET.get("invitation_id") or request.session.get("pending_invitation")
 
-    redirect_to = "http://127.0.0.1:8000/auth/callback"
+    redirect_to = f"{settings.BACKEND_URL}/auth/callback"
+    
     if invitation_id:
         redirect_to += f"?invitation_id={invitation_id}"
 

--- a/sdBackend/settings.py
+++ b/sdBackend/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['software-design-backend.onrender.com', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ['software-design-backend.onrender.com', 'localhost']
 
 
 # Application definition


### PR DESCRIPTION
# About the Fix
An issue was raised about the login flow not working. The error 
```
invalid request: both auth code and code verifier should be non-empty
```
is shown on the URL when the `localhost:8000/auth/login` is hit. 

# How does this solution solve it?
the `oauth_login` has a `redirect` variable which holds `127.0.0.1:8000/auth/callback`. While this does redirect to the backend's callback method, it is still a different domain. Different domains are treated as separate origins and don't share cookies. 

There was never a problem with the `exchange_code_for_session()` function along with how it manages it's code_verifier in the first place. Because of hte different domains, the `get_item()` from the `AppSessionStorage` would return `None`.